### PR TITLE
Reparer IA et Mouvement

### DIFF
--- a/Assets/Prefabs/PersonnageBleu.prefab
+++ b/Assets/Prefabs/PersonnageBleu.prefab
@@ -272,14 +272,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 51f4edfe7f4958447849250eba3c8e20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  forceDeSaut: 250
+  forceDeSaut: 5
   vitesseDeplacement: 100
   rb: {fileID: 1360597426261310869}
   VerifierSolGauche: {fileID: 7823474843267781301}
   VerifierSolDroite: {fileID: 7222607906731755095}
   animator: {fileID: 5362896848760781704}
   spriteRenderer: {fileID: 8855380559291239385}
-  nombreSaut: 0
+  nombreSaut: 6
   positionInitiale: {x: 0, y: 0, z: 0}
 --- !u!95 &5362896848760781704
 Animator:

--- a/Assets/Scripts/IAScripts/VueIA.cs
+++ b/Assets/Scripts/IAScripts/VueIA.cs
@@ -137,7 +137,7 @@ public class VueIA : MonoBehaviour{
             );
 
             relPos.x -= (int)((double)relSize.x/2);
-            relPos.y += (int)Math.Ceiling((double)relSize.y/2) + 6;
+            relPos.y += (int)Math.Ceiling((double)relSize.y/2) + 4;
 
 
             Vector3Int deltaPos = new Vector3Int(

--- a/Assets/Scripts/Mouvement.cs
+++ b/Assets/Scripts/Mouvement.cs
@@ -14,7 +14,7 @@ public class Mouvement : MonoBehaviour
     public Transform VerifierSolDroite;
     public Animator animator;
     public SpriteRenderer spriteRenderer;
-    public int nombreSaut = 0;
+    public int nombreSaut;
 
     //*========================{PRIVATE}========================
     private bool aSaute;
@@ -43,6 +43,7 @@ public class Mouvement : MonoBehaviour
         auSol = Physics2D.Raycast(VerifierSolGauche.position, Vector2.down, 0.01f);
         //Debug.Log(VerifierSolDroite.position + " | " + VerifierSolGauche.position);
         float mouvementHorizontal = 0f;
+        canMove = true;
         if (Mouvement.canMove) // Si la fen�tre sauvegarde est pas ouverte
         {
          if (Input.GetKey(KeyCode.R)){
@@ -59,13 +60,13 @@ public class Mouvement : MonoBehaviour
                     mouvementHorizontal = -vitesseDeplacement * Time.deltaTime;
                 }
                 if (Input.GetKey(KeyCode.Space)){
-            
+                    Debug.Log("HERE");
                     if (auSol){
-                        AudioManager.Instance.JouerBruitage("Saut");
+                        //AudioManager.Instance.JouerBruitage("Saut");
                         aSaute = true;
                       }
                     if (nombreSaut > 0 && rb.velocity.y <= 0){
-                        AudioManager.Instance.JouerBruitage("DoubleSaut");
+                        //AudioManager.Instance.JouerBruitage("DoubleSaut");
                         aSaute = true;
                       }
                 }
@@ -79,7 +80,6 @@ public class Mouvement : MonoBehaviour
             if (nombreSaut != 2) repos = true;
             nombreSaut = 2;
         }
-
         deplacerJoueur(mouvementHorizontal);
         animator.SetFloat("Vitesse", Math.Abs(rb.velocity.x));
         animator.SetInteger("nbreSaut", nombreSaut);
@@ -95,7 +95,7 @@ public class Mouvement : MonoBehaviour
 
         if (aSaute)
         {
-            rb.AddForce(new Vector2(0.0f, forceDeSaut));
+            rb.velocity = new Vector3(0.0f, forceDeSaut);
             aSaute = false;
             auSol = false;
             nombreSaut--;


### PR DESCRIPTION
Alors, les mouvements sont cassé par l'AudioManager. @MatthieuLemaitreAuger pourrais-tu le réparer en créant une autre branche ? Ca me met une erreur quand je clique sur espace pour sauter, donc les bruitages "saut" du joueur ne marche pas dans le scripts **Mouvement.cs**.

Pour l'instant je l'ai mis en commentaire  

`AudioManager.Instance.JouerBruitage("Saut");` <-- ligne 65
`AudioManager.Instance.JouerBruitage("DoubleSaut");` <-- ligne 69