### PR TITLE
Objet IA + reparer mouvement

### DIFF
--- a/Assets/Scenes/Scene Test.unity
+++ b/Assets/Scenes/Scene Test.unity
@@ -3491,6 +3491,69 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 839664645}
   m_CullTransparentMesh: 1
+--- !u!1 &852651433
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 852651436}
+  - component: {fileID: 852651435}
+  - component: {fileID: 852651434}
+  m_Layer: 0
+  m_Name: IA
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &852651434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 852651433}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 485df1f3954a24547b4e146b39dfb2ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  collecteDonne: {fileID: 852651435}
+--- !u!114 &852651435
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 852651433}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 69a53b7307d86c042b26782625f98fa5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  joueur: {fileID: 1658261521}
+  resolutionHauteur: 15
+  resolutionLongueur: 33
+  tailleAffichageCellule: 15
+  camDecalageY: 1
+--- !u!4 &852651436
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 852651433}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.7330963, y: -0.98099756, z: 0.013836125}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &875230546
 GameObject:
   m_ObjectHideFlags: 0
@@ -6973,6 +7036,11 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1658261521 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8868492734787740866, guid: cbe8e6dc776b65e47898769a91430afd, type: 3}
+  m_PrefabInstance: {fileID: 1707001337}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1707001337
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7828,7 +7896,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8869041393907031105, guid: cbe8e6dc776b65e47898769a91430afd, type: 3}
   m_PrefabInstance: {fileID: 1707001337}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1658261521}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 51f4edfe7f4958447849250eba3c8e20, type: 3}
@@ -7995,3 +8063,4 @@ SceneRoots:
   - {fileID: 568517778}
   - {fileID: 1707001337}
   - {fileID: 915420238}
+  - {fileID: 852651436}


### PR DESCRIPTION
Alors, les mouvements sont cassé par l'AudioManager. @MatthieuLemaitreAuger pourrais-tu le réparer en créant une autre branche ? Ca me met une erreur quand je clique sur espace pour sauter, donc les bruitages "saut" du joueur ne marche pas dans le scripts **Mouvement.cs.**

Pour l'instant je l'ai mis en commentaire

`AudioManager.Instance.JouerBruitage("Saut");` <-- ligne 65
`AudioManager.Instance.JouerBruitage("DoubleSaut"); `<-- ligne 69